### PR TITLE
Assets unloading to free up VRAM

### DIFF
--- a/packages/avatar-creator/src/AvatarCreatorApp.module.css
+++ b/packages/avatar-creator/src/AvatarCreatorApp.module.css
@@ -69,6 +69,15 @@
     opacity: 1;
 }
 
+.stats {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: #fff;
+    padding: 8px;
+}
+
 @media screen and (max-width: 1024px) {
     .loading .spinner {
         top: calc(25% - 64px);
@@ -82,4 +91,4 @@
     100% {
         transform: rotate(360deg);
     }
-} 
+}

--- a/packages/avatar-creator/src/AvatarCreatorApp.tsx
+++ b/packages/avatar-creator/src/AvatarCreatorApp.tsx
@@ -56,6 +56,7 @@ export function AvatarCreatorApp({
   const [appState, setAppState] = useState<"home" | "configurator">("home");
   const [isDataLoading, setIsDataLoading] = useState(true);
   const [isAvatarLoading, setIsAvatarLoading] = useState(false);
+  const [stats, setStats] = useState("");
   // TODO - enable saving
   const enableSave = false;
 
@@ -75,6 +76,10 @@ export function AvatarCreatorApp({
     // this should be created only once
     const loader = new AvatarLoader(app, data);
     setAvatarLoader(loader);
+
+    loader.on("stats", (stats) => {
+      setStats(stats.replace(/"/g, ""));
+    });
 
     // Set up global loading listeners
     if (loader) {
@@ -171,6 +176,8 @@ export function AvatarCreatorApp({
           />
         </div>
       )}
+
+      {avatarLoader && avatarLoader.debugAssets && <pre className={styles.stats}>{stats}</pre>}
     </div>
   );
 }

--- a/packages/avatar-creator/src/scripts/avatar-loader.ts
+++ b/packages/avatar-creator/src/scripts/avatar-loader.ts
@@ -18,6 +18,7 @@ import {
 import type { GlbContainerResource } from "playcanvas/build/playcanvas/src/framework/parsers/glb-container-resource";
 
 import { CatalogueBodyType, CatalogueData, CatalogueSkin } from "../CatalogueData";
+import { humanFileSize } from "./utils";
 
 /*
 
@@ -55,9 +56,14 @@ const slots = [
   "torso",
 ];
 
-const keyReplace = {
+const slotToClass = {
   "top:secondary": "topSecondary",
   "bottom:secondary": "bottomSecondary",
+};
+
+const classToSlot = {
+  topSecondary: "top:secondary",
+  bottomSecondary: "bottom:secondary",
 };
 
 import idleAnimationGLB from "../assets/anim/idle.glb";
@@ -65,10 +71,16 @@ import idleAnimationGLB from "../assets/anim/idle.glb";
 export class AvatarLoader extends EventHandler {
   private rootAsset: Asset | null = null;
   private assets: { [key: string]: Asset } = {};
-  private entities = {};
+  private assetsCache = new Set<Asset>();
+  private assetsCacheByUrl = new Map<string, Asset>();
+  private slotByAsset = new Map<Asset, string>();
+  private urlByAsset = new Map<Asset, string>();
+  private assetTimers = new Map<Asset, number>();
+  private assetExpires: number = 1000; // one second
 
   public urls: { [key: string]: string | null } = {};
   public loading = new Map<string, string>();
+  public debugAssets: boolean = false;
 
   private next = new Map<string, string | null>();
   private index = new Map<
@@ -102,6 +114,8 @@ export class AvatarLoader extends EventHandler {
     public data: CatalogueData,
   ) {
     super();
+
+    this.app.on("update", this.update, this);
 
     this.indexData();
   }
@@ -369,9 +383,19 @@ export class AvatarLoader extends EventHandler {
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const name = url.split("/").pop()!;
-    const asset = new Asset(name, "container", { url, filename: name });
+
+    let asset = this.assetsCacheByUrl.get(url);
+    if (!asset) {
+      asset = new Asset(name, "container", { url, filename: name });
+      this.app.assets.add(asset);
+      this.assetsCache.add(asset);
+      this.assetsCacheByUrl.set(url, asset);
+      this.assetTimers.set(asset, performance.now());
+      this.slotByAsset.set(asset, slot);
+      this.urlByAsset.set(asset, url);
+    }
+
     this.loading.set(slot, url);
-    this.app.assets.add(asset);
 
     this.urls[slot] = url;
 
@@ -420,6 +444,8 @@ export class AvatarLoader extends EventHandler {
           this.unload(slot);
         }
       }
+
+      this.updateStats();
     });
 
     asset.once("error", () => {
@@ -518,7 +544,7 @@ export class AvatarLoader extends EventHandler {
       if (key === "torso") continue;
       const url = this.urls[key];
       if (!url) continue;
-      const className = key in keyReplace ? keyReplace[key as keyof typeof keyReplace] : key;
+      const className = key in slotToClass ? slotToClass[key as keyof typeof slotToClass] : key;
       code += `${formatted ? "\t" : ""}<m-model class="${className}" src="${encodeURI(url)}"></m-model>${formatted ? "\n" : ""}`;
     }
 
@@ -574,7 +600,7 @@ export class AvatarLoader extends EventHandler {
 
     for (let i = 0; i < slots.length; i++) {
       const slot = slots[i];
-      const slotName = slot in keyReplace ? keyReplace[slot as keyof typeof keyReplace] : slot;
+      const slotName = slot in classToSlot ? classToSlot[slot as keyof typeof classToSlot] : slot;
       const node = character.querySelector(`m-model.${slot}`);
       const src = node?.getAttribute("src");
 
@@ -606,5 +632,64 @@ export class AvatarLoader extends EventHandler {
     this.slotEntities[slot].render!.materialAssets = [];
 
     delete this.urls[slot];
+  }
+
+  updateStats() {
+    if (!this.debugAssets) return;
+
+    this.fire(
+      "stats",
+      JSON.stringify(
+        {
+          assets: this.app.assets.list().length,
+          textures: humanFileSize(this.app.stats.vram.tex),
+          vertexBuffers: humanFileSize(this.app.stats.vram.vb),
+          indexBuffers: humanFileSize(this.app.stats.vram.ib),
+        },
+        null,
+        4,
+      ),
+    );
+  }
+
+  clearAssetResources(asset: Asset) {
+    this.app.assets.remove(asset);
+    asset.unload();
+
+    this.assetTimers.delete(asset);
+    this.assetsCache.delete(asset);
+    this.slotByAsset.delete(asset);
+
+    const url: string = this.urlByAsset.get(asset) as string;
+    this.assetsCacheByUrl.delete(url);
+
+    this.urlByAsset.delete(asset);
+
+    this.updateStats();
+  }
+
+  update() {
+    const now: number = performance.now();
+
+    for (const asset of this.assetsCache) {
+      if (!asset.file) {
+        continue;
+      }
+
+      const slot: string = this.slotByAsset.get(asset) as string;
+      const url: string = this.urlByAsset.get(asset) as string;
+
+      if (this.urls[slot] === url || this.next.get(slot) === url) {
+        // still active
+        this.assetTimers.set(asset, now);
+      } else {
+        // check if enough time has passed
+        const time: number = this.assetTimers.get(asset) as number;
+
+        if (now - time > this.assetExpires) {
+          this.clearAssetResources(asset);
+        }
+      }
+    }
   }
 }

--- a/packages/avatar-creator/src/scripts/avatar-loader.ts
+++ b/packages/avatar-creator/src/scripts/avatar-loader.ts
@@ -21,11 +21,9 @@ import { CatalogueBodyType, CatalogueData, CatalogueSkin } from "../CatalogueDat
 import { humanFileSize } from "./utils";
 
 /*
-
-    Implements loading, animating and rendering
-    based on provided GLB files for various slots
-
-*/
+ * Implements loading, animating and rendering
+ * based on provided GLB files for various slots
+ */
 
 /**
  * Fired when new GLB has started loading for a slot
@@ -68,6 +66,9 @@ const classToSlot = {
 
 import idleAnimationGLB from "../assets/anim/idle.glb";
 
+// Assets are removed from the cache after 1 seconds
+const ASSET_EXPIRES = 1000;
+
 export class AvatarLoader extends EventHandler {
   private rootAsset: Asset | null = null;
   private assets: { [key: string]: Asset } = {};
@@ -76,7 +77,6 @@ export class AvatarLoader extends EventHandler {
   private slotByAsset = new Map<Asset, string>();
   private urlByAsset = new Map<Asset, string>();
   private assetTimers = new Map<Asset, number>();
-  private assetExpires: number = 1000; // one second
 
   public urls: { [key: string]: string | null } = {};
   public loading = new Map<string, string>();
@@ -115,7 +115,7 @@ export class AvatarLoader extends EventHandler {
   ) {
     super();
 
-    this.app.on("update", this.update, this);
+    this.app.on("update", this.checkAssetsCache, this);
 
     this.indexData();
   }
@@ -553,6 +553,10 @@ export class AvatarLoader extends EventHandler {
     return code;
   }
 
+  /**
+   * Loads an avatar from an MML code
+   * @param {string} code The MML code to load
+   */
   loadAvatarMml(code: string) {
     const parser = new DOMParser();
     const doc = parser.parseFromString(code, "text/html");
@@ -634,6 +638,10 @@ export class AvatarLoader extends EventHandler {
     delete this.urls[slot];
   }
 
+  /**
+   * Updates the stats for stored assets
+   * This is only used for debugging and displayed when the debugAssets flag is true
+   */
   updateStats() {
     if (!this.debugAssets) return;
 
@@ -652,6 +660,10 @@ export class AvatarLoader extends EventHandler {
     );
   }
 
+  /**
+   * Clears an asset from the cache
+   * @param {Asset} asset The asset to clear from the cache
+   */
   clearAssetResources(asset: Asset) {
     this.app.assets.remove(asset);
     asset.unload();
@@ -664,11 +676,14 @@ export class AvatarLoader extends EventHandler {
     this.assetsCacheByUrl.delete(url);
 
     this.urlByAsset.delete(asset);
-
-    this.updateStats();
   }
 
-  update() {
+  /**
+   * Called on update from playcanvas
+   * Clears any assets that have not been used within the expire time
+   * Resets the expiry time for assets currently still active
+   */
+  checkAssetsCache() {
     const now: number = performance.now();
 
     for (const asset of this.assetsCache) {
@@ -686,10 +701,12 @@ export class AvatarLoader extends EventHandler {
         // check if enough time has passed
         const time: number = this.assetTimers.get(asset) as number;
 
-        if (now - time > this.assetExpires) {
+        if (now - time > ASSET_EXPIRES) {
           this.clearAssetResources(asset);
         }
       }
     }
+
+    this.updateStats();
   }
 }

--- a/packages/avatar-creator/src/scripts/utils.ts
+++ b/packages/avatar-creator/src/scripts/utils.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright Improbable MV Limited.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://github.com/msquared-io/avatar-creator/blob/main/LICENSE
+ */
+
+export const humanFileSize = (bytes: number, precision: number = 2) => {
+  const thresh: number = 1024;
+
+  if (Math.abs(bytes) < thresh) {
+    return bytes + " B";
+  }
+
+  const units = ["KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+  let u: number = -1;
+  const r = 10 ** precision;
+
+  do {
+    bytes /= thresh;
+    ++u;
+  } while (Math.round(Math.abs(bytes) * r) / r >= thresh && u < units.length - 1);
+
+  return bytes.toFixed(precision) + " " + units[u];
+};


### PR DESCRIPTION
Fixes https://github.com/msquared-io/avatar-creator/issues/15

This PR implements a cache of assets as well as ability to unload assets when they are not in use and have been not in use certain amount of time (1 second atm).
There is also a debug panel for stats, enabled by `assetLoader.debugAssets`.