### PR TITLE
chore: improve avatar loading (WP-5514)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8052,7 +8052,7 @@
     },
     "packages/avatar-creator": {
       "name": "@msquared/avatar-creator",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "license": "MIT",
       "dependencies": {
         "highlight.js": "^11.11.1",

--- a/packages/avatar-creator/package.json
+++ b/packages/avatar-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msquared/avatar-creator",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "A tool to create avatars",
   "homepage": "https://github.com/msquared-io/avatar-creator",
   "license": "MIT",

--- a/packages/avatar-creator/src/AvatarCreatorApp.tsx
+++ b/packages/avatar-creator/src/AvatarCreatorApp.tsx
@@ -88,32 +88,78 @@ export function AvatarCreatorApp({
     loadData();
   }, [dataUrl]);
 
+  /**
+   * Checks for the current loading state of the avatar loader and updates the state accordingly.
+   * It uses requestAnimationFrame() (which is more efficient than setInterval) to check the loading state periodically.
+   * The loading state determines whether we show a loading spinner on top of the avatar.
+   */
   useEffect(() => {
     if (!app || !data || avatarLoader) return;
-    // this should be created only once
+    // This should be created only once
     const loader = new AvatarLoader(app, data, animations);
     setAvatarLoader(loader);
 
-    loader.on("stats", (stats) => {
+    const statsHandle = loader.on("stats", (stats) => {
       setStats(stats.replace(/"/g, ""));
     });
 
-    // Set up global loading listeners
-    if (loader) {
-      // Listen for any loading events
-      const checkLoading = () => {
-        if (loader?.loadingUrlBySlot?.size > 0) {
-          setIsAvatarLoading(true);
-        } else {
-          setIsAvatarLoading(false);
-        }
-      };
+    let prevLoadingURLsSize = loader.loadingUrlBySlot.size;
+    let rafId: number | null = null;
+    let isMounted = true;
 
-      // Set up interval to check loading state
-      const interval = setInterval(checkLoading, 100);
+    const checkLoadingState = () => {
+      if (!isMounted) return;
 
-      return () => clearInterval(interval);
+      const currentLoadingURLsSize = loader.loadingUrlBySlot.size;
+
+      if (prevLoadingURLsSize === 0 && currentLoadingURLsSize > 0) {
+        setIsAvatarLoading(true);
+      } else if (prevLoadingURLsSize > 0 && currentLoadingURLsSize === 0) {
+        setIsAvatarLoading(false);
+      }
+
+      prevLoadingURLsSize = currentLoadingURLsSize;
+
+      if (currentLoadingURLsSize > 0) {
+        rafId = requestAnimationFrame(checkLoadingState);
+      } else {
+        rafId = null;
+      }
+    };
+
+    const startPollingIfNeeded = () => {
+      if (rafId === null) {
+        rafId = requestAnimationFrame(checkLoadingState);
+      }
+    };
+
+    // Kick once in case loading already started
+    if (prevLoadingURLsSize > 0) {
+      setIsAvatarLoading(true);
+      startPollingIfNeeded();
     }
+
+    // Start polling whenever a new load is initiated
+    const originalLoad = loader.load.bind(loader);
+    loader.load = (slot: string, url: string) => {
+      startPollingIfNeeded();
+      return originalLoad(slot, url);
+    };
+
+    const originalLoadCustom = loader.loadCustom.bind(loader);
+    loader.loadCustom = (slot: string, url: string, objectUrl: string) => {
+      startPollingIfNeeded();
+      return originalLoadCustom(slot, url, objectUrl);
+    };
+
+    return () => {
+      isMounted = false;
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      if (statsHandle) statsHandle.off();
+      // restore original methods
+      loader.load = originalLoad;
+      loader.loadCustom = originalLoadCustom;
+    };
   }, [app, data]);
 
   const getAvatarMml = useCallback(() => {

--- a/packages/avatar-creator/src/components/Configurator.tsx
+++ b/packages/avatar-creator/src/components/Configurator.tsx
@@ -282,16 +282,11 @@ export default function Configurator({
   const [shouldRandomizeAvatar, setShouldRandomizeAvatar] = useState(true);
 
   useEffect(() => {
-    if (avatarLoader.preventRandom || !shouldRandomizeAvatar) {
-      if (shouldRandomizeAvatar) {
-        setShouldRandomizeAvatar(false);
-      }
-      return;
+    if (shouldRandomizeAvatar) {
+      randomAll();
+      setShouldRandomizeAvatar(false);
     }
-
-    randomAll();
-    setShouldRandomizeAvatar(false);
-  }, [bodyType]);
+  }, [shouldRandomizeAvatar]);
 
   useEffect(() => {
     if (outfit) {

--- a/packages/avatar-creator/src/components/Configurator.tsx
+++ b/packages/avatar-creator/src/components/Configurator.tsx
@@ -10,7 +10,7 @@ import { AppBase } from "playcanvas";
 import * as React from "react";
 import { useEffect, useState } from "react";
 
-import { AvatarLoader } from "../scripts/avatar-loader";
+import { ALL_SLOTS_WITHOUT_OUTFIT, AvatarLoader } from "../scripts/avatar-loader";
 import {
   Catalog,
   CatalogBasicPart,
@@ -239,18 +239,7 @@ export default function Configurator({
           const obj = URL.createObjectURL(file);
 
           if (slot === "outfit") {
-            const slots = [
-              "head",
-              "hair",
-              "top",
-              "top:secondary",
-              "bottom",
-              "bottom:secondary",
-              "shoes",
-              "legs",
-              "torso",
-            ];
-            for (const slot of slots) {
+            for (const slot of ALL_SLOTS_WITHOUT_OUTFIT) {
               avatarLoader.unload(slot);
             }
 
@@ -283,12 +272,18 @@ export default function Configurator({
     };
   }, []);
 
+  const [shouldRandomizeAvatar, setShouldRandomizeAvatar] = useState(true);
+
   useEffect(() => {
-    if (avatarLoader.preventRandom) {
-      avatarLoader.preventRandom = false;
+    if (avatarLoader.preventRandom || !shouldRandomizeAvatar) {
+      if (shouldRandomizeAvatar) {
+        setShouldRandomizeAvatar(false);
+      }
       return;
     }
+
     randomAll();
+    setShouldRandomizeAvatar(false);
   }, [bodyType]);
 
   useEffect(() => {
@@ -302,8 +297,8 @@ export default function Configurator({
         return;
       }
       // If fail to find the skin sibling of the current head then select a random one.
+      randomSlot("head");
     }
-    randomSlot("head");
   }, [skin, outfit]);
 
   // Ensure the avatar load has the configurator initial state applied on load.
@@ -461,18 +456,7 @@ export default function Configurator({
       avatarLoader.legs = false;
       avatarLoader.torso = false;
 
-      const slots = [
-        "torso",
-        "legs",
-        "head",
-        "hair",
-        "top",
-        "top:secondary",
-        "bottom",
-        "bottom:secondary",
-        "shoes",
-      ];
-      for (const slot of slots) {
+      for (const slot of ALL_SLOTS_WITHOUT_OUTFIT) {
         avatarLoader.unload(slot);
       }
       avatarLoader.load("outfit", outfit);
@@ -578,6 +562,8 @@ export default function Configurator({
               bodyType={bodyType}
               setBodyType={(value) => {
                 setBodyType(value);
+                // Assets are body type specific, so we need to randomize the avatar if the body type changes
+                setShouldRandomizeAvatar(true);
               }}
               avatarLoader={avatarLoader}
             />

--- a/packages/avatar-creator/src/components/Configurator.tsx
+++ b/packages/avatar-creator/src/components/Configurator.tsx
@@ -111,11 +111,18 @@ export default function Configurator({
   };
 
   const randomAll = (exception = "") => {
+    avatarLoader.startRandomization();
+
     (Object.keys(setters) as CatalogPartKey[]).forEach((key) => {
       if (key === "outfit") return;
       if (key === exception) return;
       randomSlot(key);
     });
+
+    // Delay completion trigger to _hopefully_ avoid race conditions if we try to import an avatar during randomization.
+    setTimeout(() => {
+      avatarLoader.completeRandomization();
+    }, 300);
   };
 
   const randomSlot = (slot: CatalogPartKey) => {

--- a/packages/avatar-creator/src/scripts/avatar-loader.ts
+++ b/packages/avatar-creator/src/scripts/avatar-loader.ts
@@ -741,19 +741,12 @@ export class AvatarLoader extends EventHandler {
         this.load("torso", torsoSrc);
       }
 
-      const slots = [
-        "legs",
-        "head",
-        "hair",
-        "top",
-        "topSecondary",
-        "bottom",
-        "bottomSecondary",
-        "shoes",
-      ];
+      const ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT_AND_TORSO = ALL_SLOTS_CLASS_NAMES.filter(
+        (slot) => slot !== "outfit" && slot !== "torso",
+      );
 
-      for (let i = 0; i < slots.length; i++) {
-        const slot = slots[i];
+      for (let i = 0; i < ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT_AND_TORSO.length; i++) {
+        const slot = ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT_AND_TORSO[i];
         const slotName = slot in classToSlot ? classToSlot[slot as keyof typeof classToSlot] : slot;
         const node = character.querySelector(`m-model.${slot}`);
         const src = node?.getAttribute("src");

--- a/packages/avatar-creator/src/scripts/avatar-loader.ts
+++ b/packages/avatar-creator/src/scripts/avatar-loader.ts
@@ -67,7 +67,11 @@ const slotToClass = {
 };
 
 const ALL_SLOTS_CLASS_NAMES = [
-  ...ALL_SLOTS.map((slot) => slotToClass[slot as keyof typeof slotToClass]),
+  ...ALL_SLOTS.map((slot) =>
+    slotToClass[slot as keyof typeof slotToClass]
+      ? slotToClass[slot as keyof typeof slotToClass]
+      : slot,
+  ),
 ];
 
 const classToSlot = {

--- a/packages/avatar-creator/src/scripts/avatar-loader.ts
+++ b/packages/avatar-creator/src/scripts/avatar-loader.ts
@@ -134,6 +134,31 @@ export class AvatarLoader extends EventHandler {
 
   private animGraphData: AnimGraphData = generateDefaultAnimGraph();
 
+  private isRandomizing: boolean = false;
+  private postRandomizationQueue: Array<() => void> = [];
+
+  startRandomization() {
+    this.isRandomizing = true;
+  }
+
+  completeRandomization() {
+    this.isRandomizing = false;
+
+    // Process any queued operations
+    while (this.postRandomizationQueue.length > 0) {
+      const operation = this.postRandomizationQueue.shift();
+      operation?.();
+    }
+  }
+
+  queueAfterRandomization(operation: () => void) {
+    if (!this.isRandomizing) {
+      operation();
+    } else {
+      this.postRandomizationQueue.push(operation);
+    }
+  }
+
   /**
    * @param {AppBase} app PlayCanvas AppBase
    * @param {Object} data Data that contains all urls for slots, with their related flags (e.g. if slot should also show a torso or legs)
@@ -681,92 +706,97 @@ export class AvatarLoader extends EventHandler {
   }
 
   /**
-   * Loads an avatar from an MML code
+   * Loads an avatar from an MML code. Note that this will be called after randomization has completed.
    * @param {string} code The MML code to load
    */
   loadAvatarMml(code: string) {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(code, "text/html");
-    const rootNode = doc.body;
+    // Use the queue system to ensure this runs after any randomization
+    this.queueAfterRandomization(() => {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(code, "text/html");
+      const rootNode = doc.body;
 
-    const character = rootNode.querySelector("m-character");
-    if (!character) {
-      console.log("character not found");
-      return;
-    }
-
-    const classItems = Array.from(character.classList);
-    const outfit = classItems.includes("outfit");
-
-    if (outfit) {
-      const ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT = ALL_SLOTS_CLASS_NAMES.filter(
-        (slot) => slot !== "outfit",
-      );
-
-      this.torso = false;
-      this.legs = false;
-
-      // Unload all slots except outfit
-      for (let i = 0; i < ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT.length; i++) {
-        const slot = ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT[i];
-        const slotName = slot in classToSlot ? classToSlot[slot as keyof typeof classToSlot] : slot;
-        this.unload(slotName);
+      const character = rootNode.querySelector("m-character");
+      if (!character) {
+        console.log("character not found");
+        return;
       }
 
-      // Load the outfit
-      const src = character.getAttribute("src");
-      if (src) {
-        this.load("outfit", src);
-      }
-    } else {
-      // body type
-      const bodyTypes = new Set(["bodyA", "bodyB"]);
-      const bodyType =
-        classItems.filter((item) => {
-          return bodyTypes.has(item);
-        })?.[0] ?? "bodyA";
-      this.setBodyType(bodyType as CatalogBodyTypeKey, true);
+      const classItems = Array.from(character.classList);
+      const outfit = classItems.includes("outfit");
 
-      // skin
-      classItems.forEach((item) => {
-        if (!item.startsWith("skin")) return;
+      if (outfit) {
+        const ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT = ALL_SLOTS_CLASS_NAMES.filter(
+          (slot) => slot !== "outfit",
+        );
 
-        const skinIndex = parseInt(item.slice(4), 10);
-        if (isNaN(skinIndex)) return;
+        this.torso = false;
+        this.legs = false;
 
-        const skinName = (skinIndex + "").padStart(2, "0");
-
-        this.setSkin({ name: skinName }, true);
-      });
-
-      // Load torso
-      const torsoSrc = character.getAttribute("src");
-      if (torsoSrc) {
-        this.load("torso", torsoSrc);
-      }
-
-      const ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT_AND_TORSO = ALL_SLOTS_CLASS_NAMES.filter(
-        (slot) => slot !== "outfit" && slot !== "torso",
-      );
-
-      for (let i = 0; i < ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT_AND_TORSO.length; i++) {
-        const slot = ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT_AND_TORSO[i];
-        const slotName = slot in classToSlot ? classToSlot[slot as keyof typeof classToSlot] : slot;
-        const node = character.querySelector(`m-model.${slot}`);
-        const src = node?.getAttribute("src");
-
-        if (!src) {
+        // Unload all slots except outfit
+        for (let i = 0; i < ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT.length; i++) {
+          const slot = ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT[i];
+          const slotName =
+            slot in classToSlot ? classToSlot[slot as keyof typeof classToSlot] : slot;
           this.unload(slotName);
-          continue;
         }
 
-        if (slot === "legs") {
-          this.legs = true;
+        // Load the outfit
+        const src = character.getAttribute("src");
+        if (src) {
+          this.load("outfit", src);
+        }
+      } else {
+        // body type
+        const bodyTypes = new Set(["bodyA", "bodyB"]);
+        const bodyType =
+          classItems.filter((item) => {
+            return bodyTypes.has(item);
+          })?.[0] ?? "bodyA";
+        this.setBodyType(bodyType as CatalogBodyTypeKey, true);
+
+        // skin
+        classItems.forEach((item) => {
+          if (!item.startsWith("skin")) return;
+
+          const skinIndex = parseInt(item.slice(4), 10);
+          if (isNaN(skinIndex)) return;
+
+          const skinName = (skinIndex + "").padStart(2, "0");
+
+          this.setSkin({ name: skinName }, true);
+        });
+
+        // Load torso
+        const torsoSrc = character.getAttribute("src");
+        if (torsoSrc) {
+          this.load("torso", torsoSrc);
         }
 
-        this.load(slotName, src);
+        const ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT_AND_TORSO = ALL_SLOTS_CLASS_NAMES.filter(
+          (slot) => slot !== "outfit" && slot !== "torso",
+        );
+
+        for (let i = 0; i < ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT_AND_TORSO.length; i++) {
+          const slot = ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT_AND_TORSO[i];
+          const slotName =
+            slot in classToSlot ? classToSlot[slot as keyof typeof classToSlot] : slot;
+          const node = character.querySelector(`m-model.${slot}`);
+          const src = node?.getAttribute("src");
+
+          if (!src) {
+            this.unload(slotName);
+            continue;
+          }
+
+          if (slot === "legs") {
+            this.legs = true;
+          }
+
+          this.load(slotName, src);
+        }
       }
-    }
+    });
   }
 
   /**

--- a/packages/avatar-creator/src/scripts/avatar-loader.ts
+++ b/packages/avatar-creator/src/scripts/avatar-loader.ts
@@ -121,7 +121,6 @@ export class AvatarLoader extends EventHandler {
   // As we only care about Torso and Leg rendering only the top and bottom slots are indexed.
   private slotModelUrlToPart = new Map<string, CatalogBasicPart>();
 
-  preventRandom: boolean = false;
   torso = true;
   legs = true;
 

--- a/packages/avatar-creator/src/scripts/avatar-loader.ts
+++ b/packages/avatar-creator/src/scripts/avatar-loader.ts
@@ -46,7 +46,7 @@ import { humanFileSize } from "./utils";
  */
 
 // supported slots
-const slots = [
+export const ALL_SLOTS = [
   "head",
   "hair",
   "top",
@@ -59,10 +59,16 @@ const slots = [
   "outfit",
 ];
 
+export const ALL_SLOTS_WITHOUT_OUTFIT = [...ALL_SLOTS.filter((slot) => slot !== "outfit")];
+
 const slotToClass = {
   "top:secondary": "topSecondary",
   "bottom:secondary": "bottomSecondary",
 };
+
+const ALL_SLOTS_CLASS_NAMES = [
+  ...ALL_SLOTS.map((slot) => slotToClass[slot as keyof typeof slotToClass]),
+];
 
 const classToSlot = {
   topSecondary: "top:secondary",
@@ -169,9 +175,9 @@ export class AvatarLoader extends EventHandler {
       }
     });
 
-    for (let i = 0; i < slots.length; i++) {
-      const entity = new Entity(slots[i]);
-      this.slotEntities[slots[i]] = entity;
+    for (let i = 0; i < ALL_SLOTS.length; i++) {
+      const entity = new Entity(ALL_SLOTS[i]);
+      this.slotEntities[ALL_SLOTS[i]] = entity;
       entity.addComponent("render", {
         type: "asset",
         rootBone: this.entity,
@@ -472,12 +478,18 @@ export class AvatarLoader extends EventHandler {
    */
   uncheckBodySlot(slot: string, url: string) {
     if (slot === "top") {
-      if (!this.slotModelUrlToPart.get(`${slot}-${url}`)?.torso && this.currentUrlBySlot[slot]) {
+      const partInfo = this.slotModelUrlToPart.get(`${slot}-${url}`);
+      const hasCurrentUrl = !!this.currentUrlBySlot[slot];
+
+      if (!partInfo?.torso && hasCurrentUrl) {
         this.torso = false;
         this.loadTorso();
       }
     } else if (slot === "bottom") {
-      if (!this.slotModelUrlToPart.get(`${slot}-${url}`)?.legs && this.currentUrlBySlot[slot]) {
+      const partInfo = this.slotModelUrlToPart.get(`${slot}-${url}`);
+      const hasCurrentUrl = !!this.currentUrlBySlot[slot];
+
+      if (!partInfo?.legs && hasCurrentUrl) {
         this.legs = false;
         this.unload("legs");
       }
@@ -683,27 +695,21 @@ export class AvatarLoader extends EventHandler {
     const outfit = classItems.includes("outfit");
 
     if (outfit) {
-      const slots = [
-        "torso",
-        "legs",
-        "head",
-        "hair",
-        "top",
-        "topSecondary",
-        "bottom",
-        "bottomSecondary",
-        "shoes",
-      ];
+      const ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT = ALL_SLOTS_CLASS_NAMES.filter(
+        (slot) => slot !== "outfit",
+      );
 
       this.torso = false;
       this.legs = false;
 
-      for (let i = 0; i < slots.length; i++) {
-        const slot = slots[i];
+      // Unload all slots except outfit
+      for (let i = 0; i < ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT.length; i++) {
+        const slot = ALL_SLOTS_CLASS_NAMES_WITHOUT_OUTFIT[i];
         const slotName = slot in classToSlot ? classToSlot[slot as keyof typeof classToSlot] : slot;
         this.unload(slotName);
       }
 
+      // Load the outfit
       const src = character.getAttribute("src");
       if (src) {
         this.load("outfit", src);
@@ -729,6 +735,7 @@ export class AvatarLoader extends EventHandler {
         this.setSkin({ name: skinName }, true);
       });
 
+      // Load torso
       const torsoSrc = character.getAttribute("src");
       if (torsoSrc) {
         this.load("torso", torsoSrc);
@@ -769,14 +776,23 @@ export class AvatarLoader extends EventHandler {
    * @param {('head'|'hair'|'top'|'top:secondary'|'bottom'|"bottom:secondary"|'shoes'|'legs'|'torso')} slot Slot to unload
    */
   unload(slot: string) {
-    // Ensure that any item in the queue to load is cleared.
-    if (this.loadingUrlBySlot.has(slot)) {
-      // Fire the loaded event on the item that will no longer be loaded so that the loading state on the item is cleared.
-      this.fire(`loaded:${slot}:${this.nextUrlBySlot.get(slot)}`);
-      this.nextUrlBySlot.delete(slot);
+    // Check if the slot is currently loading something
+    const isLoading = this.loadingUrlBySlot.has(slot);
+
+    // If the slot is currently loading, we need to clear the loading state
+    if (isLoading) {
+      const nextUrl = this.nextUrlBySlot.get(slot);
+
+      // Fire the loaded event to clear the loading state
+      if (nextUrl) {
+        this.fire(`loaded:${slot}:${nextUrl}`);
+        this.nextUrlBySlot.delete(slot);
+      }
+
       return;
     }
 
+    // If we have a slot entity, clear its assets
     if (this.slotEntities[slot]) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this.slotEntities[slot].render!.asset = 0;
@@ -784,6 +800,7 @@ export class AvatarLoader extends EventHandler {
       this.slotEntities[slot].render!.materialAssets = [];
     }
 
+    // Remove the URL from currentUrlBySlot
     delete this.currentUrlBySlot[slot];
   }
 


### PR DESCRIPTION
- Using some descriptive constant names now instead of "slots" which was confusing
- Only randomizing 1. on initial load, 2. when the user chooses to change the body. Crucially, _not_ randomizing when the body changes because of a triggered import.
- Using `requestAnimationFrame` instead of `setInterval` to set the expected state of the loading spinner. This makes the useEffect hook run only when relevant. 

But the "meat" of this PR is not a perfect fix but definitely an improvement: 
- Create a queue of tasks to be implemented after "randomization is complete". This moment is hard to pinpoint precisely, so in this case it means "after 300ms" 😅. However, for a relatively fast network, it avoids race conditions between randomizations and imports. 

I recommend hiding whitespace changes. 