### PR TITLE
fix: hash set when loading assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8052,7 +8052,7 @@
     },
     "packages/avatar-creator": {
       "name": "@msquared/avatar-creator",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "license": "MIT",
       "dependencies": {
         "highlight.js": "^11.11.1",

--- a/packages/avatar-creator/package.json
+++ b/packages/avatar-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@msquared/avatar-creator",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "A tool to create avatars",
   "homepage": "https://github.com/msquared-io/avatar-creator",
   "license": "MIT",

--- a/packages/avatar-creator/src/scripts/avatar-loader.ts
+++ b/packages/avatar-creator/src/scripts/avatar-loader.ts
@@ -316,7 +316,6 @@ export class AvatarLoader extends EventHandler {
       asset = new Asset(url, "container", {
         url,
         filename: name,
-        hash: url,
       });
       this.app.assets.add(asset);
       this.assetsCacheByUrl.set(url, asset);
@@ -442,7 +441,7 @@ export class AvatarLoader extends EventHandler {
   updateStats() {
     if (!this.debugAssets) return;
 
-    console.log(
+    this.fire(
       "stats",
       JSON.stringify(
         {


### PR DESCRIPTION
this was previously needed to not unload assets when they are reused as primary and secondary. Seems this is no longer needed and it is causing some weird fetch calls with cache busting params which fail.

also fixes the stats - pushes them to the ui not console